### PR TITLE
Add Tags to Organizations

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -39,6 +39,7 @@ class Company < ApplicationRecord
   has_many :company_markets, dependent: :destroy
   has_many :markets, through: :company_markets
   has_many :deals, dependent: :destroy
+  has_many :tags, dependent: :destroy
 
   # Nested
   accepts_nested_attributes_for :locations

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,7 @@
+class Tag < ApplicationRecord
+  belongs_to :company
+
+  TAGS = %w[SAAS NON_SAAS].freeze
+
+  validates :name, inclusion: { in: TAGS }
+end

--- a/app/services/companies/searcher.rb
+++ b/app/services/companies/searcher.rb
@@ -24,7 +24,8 @@ module Companies
         employees_count: :filter_by_number,
         location: :filter_by_location,
         rounds_count: :filter_by_rounds,
-        funds_raised: :filter_by_funds
+        funds_raised: :filter_by_funds,
+        tag: :filter_by_tag
       }
     end
 
@@ -51,8 +52,14 @@ module Companies
 
     def filter_by_funds(_name, operator, value)
       @filter = @filter.joins(:deals)
-                        .having("SUM(amount_cents) #{operator} #{value}")
-                        .group(:id)
+                       .having("SUM(amount_cents) #{operator} #{value}")
+                       .group(:id)
+    end
+
+    def filter_by_tag(_name, operator, value)
+      @filter = @filter.joins(:tags)
+                       .where("tags.name #{operator} ?", value)
+                       .group(:id)
     end
 
     def format(operator, value)

--- a/app/views/companies/_filters.html.erb
+++ b/app/views/companies/_filters.html.erb
@@ -141,6 +141,11 @@
                   <%= t('filters.funds_raised') %> <i class="glyphicon glyphicon-chevron-right"></i>
                 </a>
               </li>
+              <li>
+                <a href="" data-subcategory="tag" data-type="text-completion">
+                  <%= t('filters.tags') %> <i class="glyphicon glyphicon-chevron-right"></i>
+                </a>
+              </li>
             </ul>
           </div>
           <div class="level-filter last-level-filter">

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -31,6 +31,7 @@
     </div>
     <div class="row">
       <div class="col-md-12">
+
         <%= render partial: 'shared/flash_messages' %>
 
         <div class="table-responsive">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,7 @@ en:
     stage: 'Stage'
     number_of_deals: 'Number of Deals'
     total_funds_invested: 'Total Funds Invested'
+    tags: 'Tags'
     labels:
       status:
         active: 'Active'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -486,6 +486,7 @@ es:
     stage: 'Etapa'
     number_of_deals: 'Número de Negocios'
     total_funds_invested: 'Total Invertido'
+    tags: 'Tags'
     labels:
       status:
         active: 'Activa'

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -489,6 +489,7 @@ pt-br:
     stage: 'Estágio'
     number_of_deals: 'Número de negócios'
     total_funds_invested: 'Total Investido'
+    tags: 'Tags'
     labels:
       status:
         active: 'Ativa'

--- a/db/migrate/20190704202548_create_tags.rb
+++ b/db/migrate/20190704202548_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[5.1]
+  def change
+    create_table :tags do |t|
+      t.string :name
+      t.references :company
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190325025143) do
+ActiveRecord::Schema.define(version: 20190704202548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,14 @@ ActiveRecord::Schema.define(version: 20190325025143) do
     t.index ["company_id"], name: "index_person_companies_on_company_id"
     t.index ["job_title"], name: "index_person_companies_on_job_title"
     t.index ["person_id"], name: "index_person_companies_on_person_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.bigint "company_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_tags_on_company_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :tag do
+    name { 'SAAS' }
+
+    company
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,19 @@
+describe Tag, type: :model do
+  context 'validations' do
+    let(:company) { create :company }
+
+    context 'belongs to company' do
+      it 'success' do
+        tag = build :tag, company: company
+
+        expect(tag.valid?).to be_truthy
+      end
+
+      it 'failure' do
+        tag = build :tag, company: nil
+
+        expect(tag.valid?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/companies/searcher_spec.rb
+++ b/spec/services/companies/searcher_spec.rb
@@ -192,6 +192,34 @@ describe Companies::Searcher do
     end
   end
 
+  context 'filters by tags' do
+    let!(:matching_company) { create :company }
+    let!(:non_matching_company) { create :company }
+    let(:operator) { 'equal' }
+    let(:value) { 'SAAS' }
+
+    let(:filter_params) do
+      {
+        filter: {
+          '0' => {
+            type: 'tag',
+            operator: operator,
+            value: value
+          }
+        }
+      }.deep_stringify_keys
+    end
+
+    before do
+      create :tag, company: matching_company, name: 'SAAS'
+      create :tag, company: non_matching_company, name: 'NON_SAAS'
+    end
+
+    context 'with exact amount' do
+      it { expect(subject.call.pluck(:id)).to eq([matching_company.id]) }
+    end
+  end
+
   context 'sorting' do
     subject { described_class.new(filter_params, company_1.domain_country_context) }
 


### PR DESCRIPTION
### Motivation
Add filters for Organizations based on tags, such as SaaS Orgs.

### Proposal solution
Create a table of Tags, storing the company and a specific tag for it. A new table was used to
easily support future tags.
